### PR TITLE
Add receipt photo support for expenses and BQ

### DIFF
--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/core/di/DatabaseModule.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/core/di/DatabaseModule.kt
@@ -121,6 +121,16 @@ object DatabaseModule {
         }
     }
 
+    private val migration4To5 = object : Migration(4, 5) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE local_expense ADD COLUMN receiptImageUrl TEXT")
+            db.execSQL("ALTER TABLE local_expense ADD COLUMN receiptLocalUri TEXT")
+            db.execSQL(
+                "ALTER TABLE local_expense ADD COLUMN receiptSyncStatus TEXT NOT NULL DEFAULT 'none'"
+            )
+        }
+    }
+
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): SmartFinanceDatabase {
@@ -132,6 +142,7 @@ object DatabaseModule {
             .addMigrations(migration1To2)
             .addMigrations(migration2To3)
             .addMigrations(migration3To4)
+            .addMigrations(migration4To5)
             .build()
     }
 

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/core/model/Expense.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/core/model/Expense.kt
@@ -11,7 +11,8 @@ data class ExpenseInsert(
     val category: String,
     val note: String? = null,
     @SerialName("occurred_at") val occurredAt: String,
-    @SerialName("client_uuid") val clientUuid: String
+    @SerialName("client_uuid") val clientUuid: String,
+    @SerialName("receipt_image_url") val receiptImageUrl: String? = null
 )
 
 @Serializable
@@ -24,5 +25,6 @@ data class ExpenseRecord(
     val note: String? = null,
     @SerialName("occurred_at") val occurredAt: String,
     @SerialName("created_at") val createdAt: String,
-    @SerialName("client_uuid") val clientUuid: String
+    @SerialName("client_uuid") val clientUuid: String,
+    @SerialName("receipt_image_url") val receiptImageUrl: String? = null
 )

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/expenses/ExpenseRemoteDataSource.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/expenses/ExpenseRemoteDataSource.kt
@@ -5,6 +5,7 @@ import com.smartfinance.core.model.ExpenseInsert
 import com.smartfinance.core.model.ExpenseRecord
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.storage.storage
 import javax.inject.Inject
 
 class ExpenseRemoteDataSource @Inject constructor(
@@ -27,6 +28,16 @@ class ExpenseRemoteDataSource @Inject constructor(
             .decodeList<ExpenseRecord>()
     }
 
+    suspend fun getExpenseById(expenseId: String): ExpenseRecord {
+        return supabaseClient.from("expenses")
+            .select {
+                filter {
+                    eq("id", expenseId)
+                }
+            }
+            .decodeSingle<ExpenseRecord>()
+    }
+
     suspend fun updateExpense(request: UpdateExpenseRequestDTO): ExpenseRecord {
         return supabaseClient.from("expenses")
             .update(
@@ -35,6 +46,7 @@ class ExpenseRemoteDataSource @Inject constructor(
                     set("note", request.note)
                     set("amount", request.amount)
                     set("occurred_at", request.occurredAt)
+                    set("receipt_image_url", request.receiptImageUrl)
                 }
             ) {
                 filter {
@@ -45,6 +57,32 @@ class ExpenseRemoteDataSource @Inject constructor(
             .decodeSingle<ExpenseRecord>()
     }
 
+    suspend fun updateReceiptImageUrl(expenseId: String, receiptImageUrl: String?): ExpenseRecord {
+        return supabaseClient.from("expenses")
+            .update(
+                {
+                    set("receipt_image_url", receiptImageUrl)
+                }
+            ) {
+                filter {
+                    eq("id", expenseId)
+                }
+                select()
+            }
+            .decodeSingle<ExpenseRecord>()
+    }
+
+    suspend fun uploadReceiptImage(
+        userId: String,
+        expenseId: String,
+        imageBytes: ByteArray
+    ): String {
+        val path = "$userId/$expenseId.jpg"
+        val bucket = supabaseClient.storage.from(RECEIPTS_BUCKET)
+        bucket.upload(path, imageBytes, upsert = true)
+        return bucket.publicUrl(path)
+    }
+
     suspend fun deleteExpense(expenseId: String) {
         supabaseClient.from("expenses")
             .delete {
@@ -52,5 +90,9 @@ class ExpenseRemoteDataSource @Inject constructor(
                     eq("id", expenseId)
                 }
             }
+    }
+
+    private companion object {
+        const val RECEIPTS_BUCKET = "expense-receipts"
     }
 }

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/expenses/SupabaseExpenseAdapter.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/expenses/SupabaseExpenseAdapter.kt
@@ -7,6 +7,7 @@ import com.smartfinance.data.local.toLocal
 import com.smartfinance.domain.expenses.ExpenseVO
 import com.smartfinance.domain.expenses.LogExpenseRequestDTO
 import com.smartfinance.domain.expenses.UpdateExpenseRequestDTO
+import kotlinx.coroutines.flow.first
 import java.time.ZoneId
 import java.util.UUID
 
@@ -16,7 +17,7 @@ class SupabaseExpenseAdapter(
 ) : ExpenseRepository {
 
     override suspend fun logExpense(request: LogExpenseRequestDTO): ExpenseVO {
-        val remoteExpense = remoteDataSource.insertExpense(
+        var remoteExpense = remoteDataSource.insertExpense(
             ExpenseInsert(
                 userId = request.userId,
                 amount = request.amount,
@@ -31,24 +32,95 @@ class SupabaseExpenseAdapter(
             )
         )
 
-        localDao.saveExpense(remoteExpense.toLocal())
+        localDao.saveExpense(
+            remoteExpense.toLocal().copy(
+                receiptLocalUri = request.receiptLocalUri,
+                receiptSyncStatus = if (request.receiptImageBytes == null) "none" else "pending"
+            )
+        )
+
+        request.receiptImageBytes?.let { imageBytes ->
+            val receiptUrl = remoteDataSource.uploadReceiptImage(
+                userId = request.userId,
+                expenseId = remoteExpense.id,
+                imageBytes = imageBytes
+            )
+            remoteExpense = remoteDataSource.updateReceiptImageUrl(remoteExpense.id, receiptUrl)
+            localDao.saveExpense(
+                remoteExpense.toLocal().copy(
+                    receiptLocalUri = request.receiptLocalUri,
+                    receiptSyncStatus = "uploaded"
+                )
+            )
+        }
+
         return remoteExpense.toDomain()
     }
-    override suspend fun getExpensesByUser(userId: String): List<ExpenseVO> {
-        val remoteExpenses = remoteDataSource.getExpensesByUser(userId)
 
-        return remoteExpenses.map { remoteExpense ->
-            remoteExpense.toDomain()
+    override suspend fun getExpensesByUser(userId: String): List<ExpenseVO> {
+        return try {
+            val remoteExpenses = remoteDataSource.getExpensesByUser(userId)
+
+            remoteExpenses.forEach { remoteExpense ->
+                val existing = localDao.getExpenseById(remoteExpense.id)
+                localDao.saveExpense(
+                    remoteExpense.toLocal().copy(
+                        receiptLocalUri = existing?.receiptLocalUri,
+                        receiptSyncStatus = if (remoteExpense.receiptImageUrl.isNullOrBlank()) {
+                            "none"
+                        } else {
+                            "uploaded"
+                        }
+                    )
+                )
+            }
+
+            remoteExpenses.map { remoteExpense ->
+                remoteExpense.toDomain()
+            }
+        } catch (exception: Exception) {
+            localDao.getExpenses(userId).first().map { localExpense ->
+                localExpense.toDomain()
+            }
         }
     }
 
     override suspend fun updateExpense(request: UpdateExpenseRequestDTO): ExpenseVO {
-        val updatedExpense = remoteDataSource.updateExpense(request)
+        var requestToUpdate = request
+        request.receiptImageBytes?.let { imageBytes ->
+            val existing = localDao.getExpenseById(request.expenseId)
+            val userId = existing?.userId ?: remoteDataSource.getExpenseById(request.expenseId).userId
+            val receiptUrl = remoteDataSource.uploadReceiptImage(
+                userId = userId,
+                expenseId = request.expenseId,
+                imageBytes = imageBytes
+            )
+            requestToUpdate = request.copy(receiptImageUrl = receiptUrl)
+            localDao.updateExpenseReceipt(
+                expenseId = request.expenseId,
+                receiptImageUrl = receiptUrl,
+                receiptLocalUri = request.receiptLocalUri,
+                receiptSyncStatus = "uploaded"
+            )
+        }
+
+        val updatedExpense = remoteDataSource.updateExpense(requestToUpdate)
+        localDao.saveExpense(
+            updatedExpense.toLocal().copy(
+                receiptLocalUri = request.receiptLocalUri,
+                receiptSyncStatus = if (updatedExpense.receiptImageUrl.isNullOrBlank()) {
+                    "none"
+                } else {
+                    "uploaded"
+                }
+            )
+        )
 
         return updatedExpense.toDomain()
     }
 
     override suspend fun deleteExpense(expenseId: String) {
         remoteDataSource.deleteExpense(expenseId)
+        localDao.deleteExpense(expenseId)
     }
 }

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/local/LocalEntities.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/local/LocalEntities.kt
@@ -36,7 +36,10 @@ data class LocalExpense(
     val note: String?,
     val occurredAt: String,
     val createdAt: String,
-    val clientUuid: String
+    val clientUuid: String,
+    val receiptImageUrl: String?,
+    val receiptLocalUri: String?,
+    val receiptSyncStatus: String
 )
 
 @Entity(tableName = "local_savings_projection")

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/local/Mappers.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/local/Mappers.kt
@@ -53,7 +53,10 @@ fun ExpenseRecord.toLocal() = LocalExpense(
     note = note,
     occurredAt = occurredAt,
     createdAt = createdAt,
-    clientUuid = clientUuid
+    clientUuid = clientUuid,
+    receiptImageUrl = receiptImageUrl,
+    receiptLocalUri = null,
+    receiptSyncStatus = if (receiptImageUrl.isNullOrBlank()) "none" else "uploaded"
 )
 
 fun ExpenseRecord.toDomain() = ExpenseVO(
@@ -65,5 +68,20 @@ fun ExpenseRecord.toDomain() = ExpenseVO(
     note = note,
     occurredAt = occurredAt,
     createdAt = createdAt,
-    clientUuid = clientUuid
+    clientUuid = clientUuid,
+    receiptImageUrl = receiptImageUrl
+)
+
+fun LocalExpense.toDomain() = ExpenseVO(
+    id = id,
+    userId = userId,
+    amount = amount,
+    currency = currency,
+    category = category,
+    note = note,
+    occurredAt = occurredAt,
+    createdAt = createdAt,
+    clientUuid = clientUuid,
+    receiptImageUrl = receiptImageUrl,
+    receiptLocalUri = receiptLocalUri
 )

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/local/SmartFinanceDao.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/local/SmartFinanceDao.kt
@@ -30,8 +30,27 @@ interface SmartFinanceDao {
     @Query("SELECT * FROM local_expense WHERE userId = :userId ORDER BY occurredAt DESC")
     fun getExpenses(userId: String): Flow<List<LocalExpense>>
 
+    @Query("SELECT * FROM local_expense WHERE id = :expenseId LIMIT 1")
+    suspend fun getExpenseById(expenseId: String): LocalExpense?
+
     @Query("DELETE FROM local_expense WHERE id = :expenseId")
     suspend fun deleteExpense(expenseId: String)
+
+    @Query(
+        """
+        UPDATE local_expense
+        SET receiptImageUrl = :receiptImageUrl,
+            receiptLocalUri = :receiptLocalUri,
+            receiptSyncStatus = :receiptSyncStatus
+        WHERE id = :expenseId
+        """
+    )
+    suspend fun updateExpenseReceipt(
+        expenseId: String,
+        receiptImageUrl: String?,
+        receiptLocalUri: String?,
+        receiptSyncStatus: String
+    )
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveSavingsProjectionCache(cache: LocalSavingsProjectionCache)

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/local/SmartFinanceDatabase.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/data/local/SmartFinanceDatabase.kt
@@ -12,7 +12,7 @@ import androidx.room.RoomDatabase
         LocalComparativeInsightCache::class,
         LocalTopCategoriesCache::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class SmartFinanceDatabase : RoomDatabase() {

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/domain/expenses/ExpenseVO.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/domain/expenses/ExpenseVO.kt
@@ -9,5 +9,7 @@ data class ExpenseVO(
     val note: String?,
     val occurredAt: String,
     val createdAt: String,
-    val clientUuid: String
+    val clientUuid: String,
+    val receiptImageUrl: String? = null,
+    val receiptLocalUri: String? = null
 )

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/domain/expenses/LogExpenseRequestDTO.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/domain/expenses/LogExpenseRequestDTO.kt
@@ -8,5 +8,7 @@ data class LogExpenseRequestDTO(
     val currency: String,
     val category: String,
     val note: String,
-    val occurredAt: LocalDateTime
+    val occurredAt: LocalDateTime,
+    val receiptImageBytes: ByteArray? = null,
+    val receiptLocalUri: String? = null
 )

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/domain/expenses/UpdateExpenseRequestDTO.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/domain/expenses/UpdateExpenseRequestDTO.kt
@@ -5,5 +5,8 @@ data class UpdateExpenseRequestDTO(
     val category: String,
     val note: String,
     val amount: Double,
-    val occurredAt: String
+    val occurredAt: String,
+    val receiptImageBytes: ByteArray? = null,
+    val receiptLocalUri: String? = null,
+    val receiptImageUrl: String? = null
 )

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/ExpenseDetailFragment.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/ExpenseDetailFragment.kt
@@ -2,12 +2,17 @@ package com.smartfinance.feature.expenses
 
 import android.app.AlertDialog
 import android.app.DatePickerDialog
+import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import android.widget.PopupMenu
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -16,6 +21,10 @@ import com.smartfinance.domain.expenses.ExpenseApplicationService
 import com.smartfinance.domain.expenses.UpdateExpenseRequestDTO
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.net.URL
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -41,6 +50,27 @@ class ExpenseDetailFragment : Fragment() {
     private var initialNote = ""
     private var initialAmount = 0.0
     private var initialDateText = ""
+    private var initialReceiptImageUrl: String? = null
+    private var selectedReceiptUri: Uri? = null
+    private var cameraReceiptUri: Uri? = null
+
+    private val pickReceiptLauncher = registerForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        if (uri != null) {
+            selectedReceiptUri = uri
+            renderReceipt(uri)
+        }
+    }
+
+    private val takeReceiptLauncher = registerForActivityResult(
+        ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success && cameraReceiptUri != null) {
+            selectedReceiptUri = cameraReceiptUri
+            renderReceipt(cameraReceiptUri)
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -70,6 +100,7 @@ class ExpenseDetailFragment : Fragment() {
         val note = requireArguments().getString(ARG_NOTE).orEmpty()
         val date = requireArguments().getString(ARG_DATE).orEmpty()
         val icon = requireArguments().getString(ARG_ICON).orEmpty()
+        initialReceiptImageUrl = requireArguments().getString(ARG_RECEIPT_IMAGE_URL)
 
         initialCategory = category
         initialNote = note
@@ -81,6 +112,7 @@ class ExpenseDetailFragment : Fragment() {
         binding.detailCategoryEditText.setText(category)
         binding.detailNoteEditText.setText(note)
         binding.detailDateEditText.setText(date)
+        renderRemoteReceipt(initialReceiptImageUrl)
     }
 
     private fun setupListeners() {
@@ -111,6 +143,21 @@ class ExpenseDetailFragment : Fragment() {
         binding.detailCategoryEditText.setOnClickListener {
             if (isEditMode) showCategoryPicker()
         }
+
+        binding.changeReceiptCameraButton.setOnClickListener {
+            if (isEditMode) {
+                cameraReceiptUri = createImageUri()
+                takeReceiptLauncher.launch(cameraReceiptUri)
+            }
+        }
+
+        binding.changeReceiptGalleryButton.setOnClickListener {
+            if (isEditMode) {
+                pickReceiptLauncher.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                )
+            }
+        }
     }
 
     private fun setEditMode(enabled: Boolean) {
@@ -125,6 +172,7 @@ class ExpenseDetailFragment : Fragment() {
         binding.detailCategoryEditText.isClickable = enabled
         binding.detailCategoryEditText.isFocusable = false
 
+        binding.detailReceiptActionsContainer.visibility = if (enabled) View.VISIBLE else View.GONE
         binding.editActionsContainer.visibility = if (enabled) View.VISIBLE else View.GONE
         binding.editExpenseIconButton.visibility = if (enabled) View.GONE else View.VISIBLE
         binding.deleteExpenseIconButton.visibility = if (enabled) View.GONE else View.VISIBLE
@@ -136,6 +184,8 @@ class ExpenseDetailFragment : Fragment() {
         binding.detailNoteEditText.setText(initialNote)
         binding.detailDateEditText.setText(initialDateText)
         selectedDate = parseLocalDate(originalOccurredAt)
+        selectedReceiptUri = null
+        renderRemoteReceipt(initialReceiptImageUrl)
     }
 
     private fun showDatePicker() {
@@ -195,15 +245,26 @@ class ExpenseDetailFragment : Fragment() {
 
         lifecycleScope.launch {
             try {
-                expenseApplicationService.updateExpense(
-                    UpdateExpenseRequestDTO(
-                        expenseId = expenseId,
-                        category = category,
-                        note = note,
-                        amount = amount,
-                        occurredAt = updatedOccurredAt
+                val receiptPayload = selectedReceiptUri?.let { uri ->
+                    withContext(Dispatchers.IO) {
+                        copyReceiptToLocalCache(uri)
+                    }
+                }
+
+                withContext(Dispatchers.IO) {
+                    expenseApplicationService.updateExpense(
+                        UpdateExpenseRequestDTO(
+                            expenseId = expenseId,
+                            category = category,
+                            note = note,
+                            amount = amount,
+                            occurredAt = updatedOccurredAt,
+                            receiptImageBytes = receiptPayload?.first,
+                            receiptLocalUri = receiptPayload?.second,
+                            receiptImageUrl = initialReceiptImageUrl
+                        )
                     )
-                )
+                }
 
                 Toast.makeText(
                     requireContext(),
@@ -302,6 +363,65 @@ class ExpenseDetailFragment : Fragment() {
         popupMenu.show()
     }
 
+    private fun renderReceipt(uri: Uri?) {
+        binding.detailReceiptImageView.visibility = if (uri == null) View.GONE else View.VISIBLE
+        binding.detailReceiptEmptyTextView.visibility = if (uri == null) View.VISIBLE else View.GONE
+        binding.detailReceiptImageView.setImageURI(uri)
+    }
+
+    private fun renderRemoteReceipt(receiptUrl: String?) {
+        if (receiptUrl.isNullOrBlank()) {
+            renderReceipt(null)
+            return
+        }
+
+        lifecycleScope.launch {
+            val bitmap = withContext(Dispatchers.IO) {
+                runCatching {
+                    URL(receiptUrl).openStream().use { stream ->
+                        BitmapFactory.decodeStream(stream)
+                    }
+                }.getOrNull()
+            }
+
+            if (bitmap != null) {
+                binding.detailReceiptImageView.visibility = View.VISIBLE
+                binding.detailReceiptEmptyTextView.visibility = View.GONE
+                binding.detailReceiptImageView.setImageBitmap(bitmap)
+            } else {
+                renderReceipt(null)
+            }
+        }
+    }
+
+    private fun createImageUri(): Uri {
+        val imageFile = File.createTempFile(
+            "expense_receipt_${System.currentTimeMillis()}",
+            ".jpg",
+            requireContext().cacheDir
+        )
+
+        return FileProvider.getUriForFile(
+            requireContext(),
+            "${requireContext().packageName}.provider",
+            imageFile
+        )
+    }
+
+    private fun copyReceiptToLocalCache(uri: Uri): Pair<ByteArray, String>? {
+        val imageBytes = requireContext().contentResolver.openInputStream(uri)?.use {
+            it.readBytes()
+        } ?: return null
+
+        val cachedFile = File(
+            requireContext().cacheDir,
+            "expense_receipt_cache_${System.currentTimeMillis()}.jpg"
+        )
+        cachedFile.writeBytes(imageBytes)
+
+        return imageBytes to Uri.fromFile(cachedFile).toString()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
@@ -315,5 +435,6 @@ class ExpenseDetailFragment : Fragment() {
         const val ARG_DATE = "date"
         const val ARG_OCCURRED_AT = "occurredAt"
         const val ARG_ICON = "icon"
+        const val ARG_RECEIPT_IMAGE_URL = "receiptImageUrl"
     }
 }

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/ExpenseItemUiModel.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/ExpenseItemUiModel.kt
@@ -7,5 +7,6 @@ data class ExpenseItemUiModel(
     val dateText: String,
     val amountText: String,
     val icon: String,
-    val occurredAt: String
+    val occurredAt: String,
+    val receiptImageUrl: String?
 )

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/LogExpenseFragment.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/LogExpenseFragment.kt
@@ -2,12 +2,16 @@ package com.smartfinance.feature.expenses
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import android.net.Uri
 import android.os.Bundle
 import android.text.InputFilter
 import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -26,7 +30,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import java.io.File
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class LogExpenseFragment : Fragment() {
@@ -43,6 +50,26 @@ class LogExpenseFragment : Fragment() {
     private var amountWarningCount = 0
     private var noteLengthWarningCount = 0
     private var noteSqlWarningCount = 0
+    private var selectedReceiptUri: Uri? = null
+    private var cameraReceiptUri: Uri? = null
+
+    private val pickReceiptLauncher = registerForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        if (uri != null) {
+            selectedReceiptUri = uri
+            renderReceiptPreview(uri)
+        }
+    }
+
+    private val takeReceiptLauncher = registerForActivityResult(
+        ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success && cameraReceiptUri != null) {
+            selectedReceiptUri = cameraReceiptUri
+            renderReceiptPreview(cameraReceiptUri)
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -140,6 +167,17 @@ class LogExpenseFragment : Fragment() {
             showTimePicker()
         }
 
+        binding.buttonTakeReceiptPhoto.setOnClickListener {
+            cameraReceiptUri = createImageUri()
+            takeReceiptLauncher.launch(cameraReceiptUri)
+        }
+
+        binding.buttonChooseReceiptPhoto.setOnClickListener {
+            pickReceiptLauncher.launch(
+                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+            )
+        }
+
         binding.buttonSaveExpense.setOnClickListener {
             submitExpense()
         }
@@ -233,16 +271,59 @@ class LogExpenseFragment : Fragment() {
 
         val resolvedCategory = category ?: return
 
-        viewModel.saveExpense(
-            LogExpenseRequestDTO(
-                userId = userId.orEmpty(),
-                amount = amount,
-                currency = currency,
-                category = resolvedCategory,
-                note = note,
-                occurredAt = selectedDateTime
+        viewLifecycleOwner.lifecycleScope.launch {
+            val receiptPayload = selectedReceiptUri?.let { uri ->
+                withContext(Dispatchers.IO) {
+                    copyReceiptToLocalCache(uri)
+                }
+            }
+
+            viewModel.saveExpense(
+                LogExpenseRequestDTO(
+                    userId = userId.orEmpty(),
+                    amount = amount,
+                    currency = currency,
+                    category = resolvedCategory,
+                    note = note,
+                    occurredAt = selectedDateTime,
+                    receiptImageBytes = receiptPayload?.first,
+                    receiptLocalUri = receiptPayload?.second
+                )
             )
+        }
+    }
+
+    private fun renderReceiptPreview(uri: Uri?) {
+        binding.receiptPreviewImageView.visibility = if (uri == null) View.GONE else View.VISIBLE
+        binding.receiptPreviewImageView.setImageURI(uri)
+    }
+
+    private fun createImageUri(): Uri {
+        val imageFile = File.createTempFile(
+            "expense_receipt_${System.currentTimeMillis()}",
+            ".jpg",
+            requireContext().cacheDir
         )
+
+        return FileProvider.getUriForFile(
+            requireContext(),
+            "${requireContext().packageName}.provider",
+            imageFile
+        )
+    }
+
+    private fun copyReceiptToLocalCache(uri: Uri): Pair<ByteArray, String>? {
+        val imageBytes = requireContext().contentResolver.openInputStream(uri)?.use {
+            it.readBytes()
+        } ?: return null
+
+        val cachedFile = File(
+            requireContext().cacheDir,
+            "expense_receipt_cache_${System.currentTimeMillis()}.jpg"
+        )
+        cachedFile.writeBytes(imageBytes)
+
+        return imageBytes to Uri.fromFile(cachedFile).toString()
     }
 
     private fun updateSaveButtonState() {

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/LogExpenseViewModel.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/LogExpenseViewModel.kt
@@ -8,10 +8,12 @@ import com.smartfinance.domain.expenses.ExpenseVO
 import com.smartfinance.domain.expenses.LogExpenseRequestDTO
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @HiltViewModel
 class LogExpenseViewModel @Inject constructor(
@@ -26,7 +28,9 @@ class LogExpenseViewModel @Inject constructor(
             _saveExpenseState.value = UiState.Loading
             try {
                 _saveExpenseState.value = UiState.Success(
-                    expenseApplicationService.logExpense(request)
+                    withContext(Dispatchers.IO) {
+                        expenseApplicationService.logExpense(request)
+                    }
                 )
             } catch (e: Exception) {
                 _saveExpenseState.value = UiState.Error(

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/MyExpensesFragment.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/MyExpensesFragment.kt
@@ -189,7 +189,8 @@ class MyExpensesFragment : Fragment() {
                 ExpenseDetailFragment.ARG_NOTE to expense.note,
                 ExpenseDetailFragment.ARG_DATE to expense.dateText,
                 ExpenseDetailFragment.ARG_OCCURRED_AT to expense.occurredAt,
-                ExpenseDetailFragment.ARG_ICON to expense.icon
+                ExpenseDetailFragment.ARG_ICON to expense.icon,
+                ExpenseDetailFragment.ARG_RECEIPT_IMAGE_URL to expense.receiptImageUrl
             )
         )
     }

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/MyExpensesViewModel.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/expenses/MyExpensesViewModel.kt
@@ -160,7 +160,8 @@ class MyExpensesViewModel @Inject constructor(
             dateText = formatDate(occurredAt),
             amountText = "${currency.uppercase()} ${String.format(Locale.US, "%.2f", amount)}",
             icon = getIconForCategory(category),
-            occurredAt = occurredAt
+            occurredAt = occurredAt,
+            receiptImageUrl = receiptImageUrl
         )
     }
 

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/spending_insights/BiggestExpenseUiModel.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/spending_insights/BiggestExpenseUiModel.kt
@@ -1,0 +1,10 @@
+package com.smartfinance.feature.spending_insights
+
+data class BiggestExpenseUiModel(
+    val amountText: String,
+    val cycleText: String,
+    val expenseDateText: String,
+    val categoryTotalText: String,
+    val categoryIcon: String,
+    val categoryText: String
+)

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/spending_insights/SpendingInsightsFragment.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/spending_insights/SpendingInsightsFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.smartfinance.R
 import com.smartfinance.databinding.FragmentSpendingInsightsBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -73,9 +74,23 @@ class SpendingInsightsFragment : Fragment() {
         binding.insightsErrorTextView.isVisible = state.errorMessage != null
         binding.insightsErrorTextView.text = state.errorMessage
 
-        // Control de visibilidad de las tarjetas
+        val hasBiggestExpense = state.biggestExpense != null
         val hasCategories = state.topCategories.isNotEmpty()
         val hasStreaks = state.streaks.isNotEmpty()
+
+        binding.biggestExpenseCard.isVisible = !state.isLoading && hasBiggestExpense
+        state.biggestExpense?.let { biggestExpense ->
+            binding.biggestExpenseAmountTextView.text = biggestExpense.amountText
+            binding.biggestExpenseCycleTextView.text = biggestExpense.cycleText
+            binding.biggestExpenseDateTextView.text = biggestExpense.expenseDateText
+            binding.biggestExpenseCategoryTotalTextView.text =
+                getString(
+                    R.string.biggest_expense_category_total,
+                    biggestExpense.categoryTotalText
+                )
+            binding.biggestExpenseCategoryIconTextView.text = biggestExpense.categoryIcon
+            binding.biggestExpenseCategoryTextView.text = biggestExpense.categoryText
+        }
 
         binding.topCategoriesCard.isVisible = !state.isLoading && hasCategories
         categoryInsightsAdapter.submitList(state.topCategories)
@@ -84,9 +99,9 @@ class SpendingInsightsFragment : Fragment() {
         binding.streaksDescriptionTextView.text = state.evaluatedAtText
         streaksAdapter.submitList(state.streaks)
 
-        // Estado vacío global
         binding.emptyInsightsTextView.isVisible = 
-            !state.isLoading && state.errorMessage == null && !hasCategories && !hasStreaks
+            !state.isLoading && state.errorMessage == null &&
+                !hasBiggestExpense && !hasCategories && !hasStreaks
     }
 
     override fun onDestroyView() {

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/spending_insights/SpendingInsightsUiState.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/spending_insights/SpendingInsightsUiState.kt
@@ -2,6 +2,7 @@ package com.smartfinance.feature.spending_insights
 
 data class SpendingInsightsUiState(
     val isLoading: Boolean = false,
+    val biggestExpense: BiggestExpenseUiModel? = null,
     val topCategories: List<CategoryInsightUiModel> = emptyList(),
     val streaks: List<CategoryStreakUiModel> = emptyList(),
     val evaluatedAtText: String? = null,

--- a/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/spending_insights/SpendingInsightsViewModel.kt
+++ b/SmartFinance-Kotlin/app/src/main/java/com/smartfinance/feature/spending_insights/SpendingInsightsViewModel.kt
@@ -52,6 +52,7 @@ class SpendingInsightsViewModel @Inject constructor(
                 if (allExpenses.isEmpty()) {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false, 
+                        biggestExpense = null,
                         topCategories = emptyList(), 
                         streaks = emptyList(),
                         evaluatedAtText = null
@@ -72,6 +73,22 @@ class SpendingInsightsViewModel @Inject constructor(
                     .mapValues { entry -> entry.value.sumOf { it.amount } }
                 
                 val totalSpent = totalByCat.values.sum()
+                val biggestExpense = currentMonthExpenses
+                    .maxByOrNull { it.amount }
+                    ?.let { expense ->
+                        val categoryKey = expense.category.lowercase().trim()
+                        BiggestExpenseUiModel(
+                            amountText = formatMoney(expense.currency, expense.amount),
+                            cycleText = formatCycle(currentMonth),
+                            expenseDateText = formatExpenseDate(expense.occurredAt),
+                            categoryTotalText = formatMoney(
+                                expense.currency,
+                                totalByCat[categoryKey] ?: expense.amount
+                            ),
+                            categoryIcon = getIconForCategory(expense.category),
+                            categoryText = formatCategoryName(expense.category)
+                        )
+                    }
                 val topCategories = totalByCat.entries
                     .sortedByDescending { it.value }
                     .map { (cat, amount) ->
@@ -109,6 +126,7 @@ class SpendingInsightsViewModel @Inject constructor(
 
                 _uiState.value = _uiState.value.copy(
                     isLoading = false,
+                    biggestExpense = biggestExpense,
                     topCategories = topCategories,
                     streaks = streaks,
                     evaluatedAtText = evaluatedAtText
@@ -127,6 +145,26 @@ class SpendingInsightsViewModel @Inject constructor(
         return when(category.lowercase().trim()) {
             "utilities", "bills" -> "Bills"
             else -> category.trim().replaceFirstChar { it.titlecase(Locale.getDefault()) }
+        }
+    }
+
+    private fun formatMoney(currency: String, amount: Double): String {
+        return "${currency.uppercase(Locale.US)} ${String.format(Locale.US, "%,.2f", amount)}"
+    }
+
+    private fun formatCycle(cycle: YearMonth): String {
+        val formatter = DateTimeFormatter.ofPattern("MMM d", Locale.US)
+        val start = cycle.atDay(1)
+        val end = cycle.atEndOfMonth()
+        return "${start.format(formatter)} - ${end.format(formatter)}, ${cycle.year}"
+    }
+
+    private fun formatExpenseDate(rawDate: String): String {
+        return try {
+            OffsetDateTime.parse(rawDate)
+                .format(DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.US))
+        } catch (_: Exception) {
+            rawDate
         }
     }
 

--- a/SmartFinance-Kotlin/app/src/main/res/layout/fragment_expense_detail.xml
+++ b/SmartFinance-Kotlin/app/src/main/res/layout/fragment_expense_detail.xml
@@ -176,6 +176,65 @@
                 android:textColor="#111827"
                 android:textSize="16sp" />
 
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="18dp"
+                android:text="@string/expense_receipt_label"
+                android:textColor="#6B7280"
+                android:textSize="13sp"
+                android:textStyle="bold" />
+
+            <ImageView
+                android:id="@+id/detailReceiptImageView"
+                android:layout_width="match_parent"
+                android:layout_height="160dp"
+                android:layout_marginTop="6dp"
+                android:background="@drawable/bg_expense_search_input"
+                android:contentDescription="@string/expense_receipt_label"
+                android:scaleType="centerCrop"
+                android:visibility="gone"
+                tools:src="@drawable/ic_launcher_background"
+                tools:visibility="visible" />
+
+            <TextView
+                android:id="@+id/detailReceiptEmptyTextView"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_marginTop="6dp"
+                android:background="@drawable/bg_expense_search_input"
+                android:gravity="center_vertical"
+                android:paddingStart="14dp"
+                android:paddingEnd="14dp"
+                android:text="@string/expense_receipt_empty"
+                android:textColor="#6B7280"
+                android:textSize="14sp" />
+
+            <LinearLayout
+                android:id="@+id/detailReceiptActionsContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:baselineAligned="false"
+                android:orientation="horizontal"
+                android:visibility="gone">
+
+                <Button
+                    android:id="@+id/changeReceiptCameraButton"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_weight="1"
+                    android:text="@string/expense_receipt_take_photo" />
+
+                <Button
+                    android:id="@+id/changeReceiptGalleryButton"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:text="@string/expense_receipt_choose_gallery" />
+            </LinearLayout>
+
             <LinearLayout
                 android:id="@+id/editActionsContainer"
                 android:layout_width="match_parent"

--- a/SmartFinance-Kotlin/app/src/main/res/layout/fragment_log_expense.xml
+++ b/SmartFinance-Kotlin/app/src/main/res/layout/fragment_log_expense.xml
@@ -201,6 +201,60 @@
                 app:strokeColor="@color/colorGray" />
         </LinearLayout>
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:text="@string/expense_receipt_label"
+            android:textColor="@color/colorTextPrimary"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <ImageView
+            android:id="@+id/receiptPreviewImageView"
+            android:layout_width="match_parent"
+            android:layout_height="160dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_expense_item"
+            android:contentDescription="@string/expense_receipt_label"
+            android:scaleType="centerCrop"
+            android:visibility="gone"
+            tools:src="@drawable/ic_launcher_background"
+            tools:visibility="visible" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonTakeReceiptPhoto"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/expense_receipt_take_photo"
+                android:textAllCaps="false"
+                android:textColor="@color/colorTextPrimary"
+                app:cornerRadius="18dp"
+                app:strokeColor="@color/colorGray" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonChooseReceiptPhoto"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
+                android:text="@string/expense_receipt_choose_gallery"
+                android:textAllCaps="false"
+                android:textColor="@color/colorTextPrimary"
+                app:cornerRadius="18dp"
+                app:strokeColor="@color/colorGray" />
+        </LinearLayout>
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/buttonSaveExpense"
             android:layout_width="match_parent"

--- a/SmartFinance-Kotlin/app/src/main/res/layout/fragment_spending_insights.xml
+++ b/SmartFinance-Kotlin/app/src/main/res/layout/fragment_spending_insights.xml
@@ -54,7 +54,6 @@
             android:textSize="14sp"
             android:visibility="gone" />
 
-        <!-- Spending by Category Card -->
         <LinearLayout
             android:id="@+id/topCategoriesCard"
             android:layout_width="match_parent"
@@ -128,6 +127,97 @@
                 android:layout_marginTop="18dp"
                 android:nestedScrollingEnabled="false"
                 tools:listitem="@layout/item_category_streak" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/biggestExpenseCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="22dp"
+            android:background="@drawable/bg_expense_item"
+            android:orientation="vertical"
+            android:padding="18dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/biggest_expense_title"
+                android:textColor="#111827"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/biggestExpenseCycleTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textColor="#6B7280"
+                android:textSize="14sp"
+                tools:text="May 1 - May 31, 2026" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/biggestExpenseAmountTextView"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textColor="#111827"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    tools:text="USD 120.00" />
+
+                <TextView
+                    android:id="@+id/biggestExpenseDateTextView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:textColor="#6B7280"
+                    android:textSize="13sp"
+                    tools:text="May 12, 2026" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/biggestExpenseCategoryTotalTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:textColor="#16A34A"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                tools:text="Total in category: USD 340.00" />
+
+            <LinearLayout
+                android:id="@+id/biggestExpenseCategoryRow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/biggestExpenseCategoryIconTextView"
+                    android:layout_width="24dp"
+                    android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    tools:text="🍴" />
+
+                <TextView
+                    android:id="@+id/biggestExpenseCategoryTextView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:textColor="#6B7280"
+                    android:textSize="14sp"
+                    tools:text="Food" />
+            </LinearLayout>
         </LinearLayout>
 
         <TextView

--- a/SmartFinance-Kotlin/app/src/main/res/navigation/nav_graph.xml
+++ b/SmartFinance-Kotlin/app/src/main/res/navigation/nav_graph.xml
@@ -143,6 +143,11 @@
             android:name="occurredAt"
             app:argType="string" />
 
+        <argument
+            android:name="receiptImageUrl"
+            app:argType="string"
+            app:nullable="true" />
+
     </fragment>
 
 </navigation>

--- a/SmartFinance-Kotlin/app/src/main/res/values/strings.xml
+++ b/SmartFinance-Kotlin/app/src/main/res/values/strings.xml
@@ -34,6 +34,12 @@
     <string name="comparison_unavailable">Not enough similar users yet.</string>
     <string name="comparison_user_label">You</string>
     <string name="comparison_cohort_label">Cohort avg</string>
+    <string name="biggest_expense_title">Biggest expense this cycle</string>
+    <string name="biggest_expense_loading">Loading biggest expense...</string>
+    <string name="biggest_expense_empty">No expenses logged this cycle yet.</string>
+    <string name="biggest_expense_cycle">Cycle: %1$s</string>
+    <string name="biggest_expense_category_total">Total in category: %1$s</string>
+    <string name="biggest_expense_category">Category: %1$s</string>
     <string name="add_expense">Add expense</string>
     <string name="expense_cancel">Cancel</string>
     <string name="log_expense_title">Log expense</string>
@@ -44,6 +50,10 @@
     <string name="expense_note_label">Note (optional)</string>
     <string name="expense_note_hint">What was it for?</string>
     <string name="expense_date_label">Date</string>
+    <string name="expense_receipt_label">Receipt photo</string>
+    <string name="expense_receipt_take_photo">Take photo</string>
+    <string name="expense_receipt_choose_gallery">Gallery</string>
+    <string name="expense_receipt_empty">No receipt photo attached.</string>
     <string name="expense_save">Save expense</string>
     <string name="expense_amount_error">Enter an amount greater than zero.</string>
     <string name="expense_amount_too_high">The amount is too high. Enter a lower amount.</string>

--- a/SmartFinance-Kotlin/tasks/lessons.md
+++ b/SmartFinance-Kotlin/tasks/lessons.md
@@ -1,0 +1,4 @@
+# Lessons
+
+- When the user says "vista de insights" in this project, map it to `spendingInsightsFragment` / `feature/spending_insights`, not the Home `insightsFragment` / `feature/plan_insights`.
+- Before placing UI in a tab, confirm the destination through `bottom_nav_menu.xml` and `nav_graph.xml`; this project labels Home's fragment as `insightsFragment`, which is easy to confuse.

--- a/SmartFinance-Kotlin/tasks/todo.md
+++ b/SmartFinance-Kotlin/tasks/todo.md
@@ -1,0 +1,97 @@
+# Project Context Review
+
+## Biggest Expense BQ Plan
+
+- [x] Re-read spending insights ViewModel, Fragment, layout, strings, and expense/domain files.
+- [x] Remove the biggest expense card from Home / plan insights.
+- [x] Add a UI model/state for biggest expense this cycle in spending insights.
+- [x] Compute biggest expense for the current cycle from user expenses and category total.
+- [x] Render the new card in `fragment_spending_insights.xml`.
+- [x] Run Android/Kotlin verification and document results.
+
+## Expense Receipt Camera Feature Plan
+
+- [x] Extend expense models/DTOs/local Room cache for one receipt image per expense.
+- [x] Add Supabase Storage upload and `receipt_image_url` updates in the expense data layer.
+- [x] Add camera/gallery picking and local cache copy to log expense.
+- [x] Add receipt display/change flow to expense detail edit mode.
+- [x] Pass receipt data through the expenses list/detail navigation.
+- [x] Verify with Android build and document results.
+
+## Plan
+
+- [x] Map project architecture, modules, dependencies, and navigation.
+- [x] Review Expenses feature end to end: views, viewmodels, domain, data, persistence, remote calls.
+- [x] Review Insights features end to end: plan insights, spending insights, comparative insights, data flow and UI behavior.
+- [x] Cross-check how Expenses data feeds or relates to Insights.
+- [x] Run verification commands available for this Android/Kotlin project.
+- [x] Document findings and open questions.
+
+## Review
+
+Completed May 22, 2026.
+
+Architecture:
+- Single Android module `:app` with Kotlin, Hilt, Navigation, ViewBinding, Supabase, Room, Coroutines, Serialization, DataStore, and Location Services.
+- Package layering is `feature/*` for UI, `domain/*` for services/facades/VOs/DTOs, `data/*` for repositories/adapters/data sources/cache, and `core/*` for shared models, DI, network, and location.
+- `MainActivity` hosts Navigation, wires bottom nav, hides it for auth/onboarding/log/detail screens, and switches start destination based on Supabase session and whether a generated plan exists.
+
+Expenses:
+- `MyExpensesFragment` lists expenses, reloads on resume, filters in memory, and opens detail/log screens.
+- `MyExpensesViewModel` reads current user from Supabase Auth, calls `ExpenseApplicationService.getExpensesByUser`, sorts by `occurredAt`, maps to `ExpenseItemUiModel`, and applies search/category/current-month filters.
+- `LogExpenseFragment` validates amount, note, category, date/time and saves through `LogExpenseViewModel`.
+- `ExpenseApplicationService` validates and normalizes categories, notably `Bills -> utilities`.
+- `SupabaseExpenseAdapter` inserts/selects/updates/deletes via `ExpenseRemoteDataSource`; create saves a Room copy, but list/update/delete do not use or maintain Room.
+- `ExpenseDetailFragment` edits/deletes directly through `ExpenseApplicationService` without a ViewModel.
+
+Insights:
+- Bottom nav has two insight surfaces: `insightsFragment` for plan insights/home and `spendingInsightsFragment` for expense-based spending insights.
+- Plan insights loads existing plan, savings projection, top categories, comparative insight, and location context.
+- Savings projection and top categories flow through `PlanInsightsApplicationService -> PlanInsightsFacade -> BqRepositoryImpl -> PlanRemoteDataSource`, calling Supabase Functions `get-bq-savings-projection` and `get-bq-top-categories`, with memory and Room cache.
+- Comparative insight is rendered inside plan insights, calls `get-bq-comparative-spending`, and caches in memory and Room.
+- Spending insights calculates locally from remote expenses: current-month spend by category and days since last spend by category.
+
+Expense/insight relationship:
+- `spending_insights` directly depends on `ExpenseApplicationService.getExpensesByUser`.
+- `plan_insights` and comparative insights depend indirectly on expenses through Supabase/BigQuery functions and only consume aggregates.
+- After saving an expense, plan insights can refresh via the `expense_saved` saved-state key when returning to that screen.
+
+Verification:
+- `./gradlew assembleDebug` passed.
+- No TypeScript type-checker or ESLint config applies to this Android/Kotlin project.
+
+Notable risks:
+- Room expense cache is incomplete and can become stale.
+- Detail screen uses navigation arguments instead of reloading by id.
+- Expense update/delete filter only by id and rely on backend/RLS for user isolation.
+- Editing an expense date drops the original time.
+- Detail amount parsing strips only `USD`, so non-USD currencies can parse as `0.0`.
+- New expense currency is inferred from the first listed expense or defaults to `USD`, not from the user's financial setup.
+- Create/edit category lists are inconsistent.
+
+## Biggest Expense BQ Review
+
+Completed May 22, 2026.
+
+- Moved `Biggest expense this cycle` out of Home / `plan_insights`.
+- Added the card to the bottom-nav Insights view / `spending_insights`.
+- `SpendingInsightsViewModel` now reuses the current expense load, filters the current month cycle, chooses the largest expense, and calculates total spent in that expense category.
+- The spending insights empty state now accounts for the new card.
+- Verification: `./gradlew assembleDebug` passed.
+
+## Expense Receipt Camera Feature Review
+
+Completed May 22, 2026.
+
+- Added optional one-photo receipt support for expenses through camera capture and gallery picking.
+- Added `receipt_image_url` mapping to the Supabase expense model.
+- Added Supabase Storage upload to bucket `expense-receipts`.
+- Added Room cache fields for receipt URL, local URI, and sync status with database migration 4 to 5.
+- Expense listing now caches remote expenses locally and falls back to Room if Supabase loading fails.
+- Log expense saves selected receipt bytes on an IO dispatcher and stores local cache metadata.
+- Expense detail shows the existing receipt and allows replacing it only in edit mode.
+- Verification: `./gradlew assembleDebug` passed.
+
+Backend requirements:
+- Add nullable column `receipt_image_url` to the Supabase `expenses` table.
+- Create/configure public bucket `expense-receipts` or adjust the app to use a private signed URL strategy.


### PR DESCRIPTION
feature de cámara/factura para expenses quedó:

  - Multi-threading / concurrency
      - Lectura/copia de imagen con Dispatchers.IO.
      - Guardado/subida del expense con foto fuera del main thread.
      - Carga de imagen remota en detalle también fuera del main thread.
  - Local storage strategy
      - Room actualizado a versión 5.
      - local_expense ahora guarda:
          - receiptImageUrl
          - receiptLocalUri
          - receiptSyncStatus
  - Caching
      - Al listar expenses, se cachean localmente en Room.
      - Si Supabase falla al cargar expenses, la app usa Room como fallback.
      - También se guarda metadata local de la imagen asociada al expense.